### PR TITLE
Add DomScan to Domain / IP / DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1509,6 +1509,7 @@ Enter two images and the difference will show up below
 - [Focsec](https://focsec.com) - IP Threat Intelligence, provides general IP information, Proxy, TOR and VPN Detection
 - [favihash](https://www.favihash.com/) - Get the hash of a favicon to identify websites using the same. Works on both open web and dark web.
 - [domain digger](https://digger.tools/) - Find all dns recoreds, whois data, ssl/tls certificate history, subdomain and more
+- [DomScan](https://domscan.net) - Domain intelligence API and MCP server: DNS, WHOIS/RDAP, SSL/TLS, subdomain enumeration, certificate search, typosquatting and brand monitoring, plus domain valuation and availability.
 - [dnslytics](https://dnslytics.com/) - search for domain IPv4, IPv6 or Provider
 - [dnstwist](https://dnstwist.it) - scan phishing domain
 - [SecurityTrails](https://securitytrails.com/) - search for domain, IPs, keyword or Hostname


### PR DESCRIPTION
Adds **DomScan** (https://domscan.net), a domain intelligence toolkit for DNS, WHOIS/RDAP, SSL/TLS, subdomain enumeration, certificate search, typosquatting and brand monitoring, plus domain valuation and availability (one API and MCP server). Added to the Domain/IP/DNS section in the existing entry format.