### PR TITLE
Add JobVerify — recruiter / job-offer scam detection (OSINT MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ In addition search for Wifi networks and look for planes, vessels, trains and ci
 - [OSINT LLM](https://huggingface.co/spaces/tomvaillant/osint-llm) - AI-powered OSINT assistant on Hugging Face.
 - [Threat Intelligence AI](https://threatlandscape.ai/) - Threat Landscape Copilot - Conversational access to continuously updated, structured threat intelligence.
 - [ai-toolkit](https://huggingface.co/spaces/JournalistsonHF/ai-toolkit) - The Essential AI Toolkit for Journalists and Content Creators, All the tools listed here are free to use and open-source!
+- [JobVerify](https://github.com/yessGlory17/job-verify) - MCP server that checks whether a recruiter or job offer is a scam. Extracts entities from a pasted message and cross-checks company registration, domain age, look-alike/typosquat domains, phishing/malware blocklists, email deliverability, crypto-scam databases, and Internet Archive history. Free OSINT, no API keys.
 
 ### AI Image & Video Generation
 - [StockimgAI](https://stockimg.ai/) - This AI tool helps you create beautiful images for your brand, such as: Logos, Wallpaper, Book covers.


### PR DESCRIPTION
Adds **JobVerify** under *AI for OSINT & Threat Intelligence*.

JobVerify is a free, open-source MCP server (works with Claude and other AI assistants) that helps you check whether a recruiter message or job offer is a scam, before you reply. You paste a message and it extracts entities (company, links, email, phone, crypto wallets) and cross-checks them against public OSINT sources: company registration & scam reports, domain age / spoofability (SPF/DKIM/DMARC) / certificate transparency, look-alike & typosquatting domains, phishing & malware blocklists, email deliverability, known-scam crypto wallet databases, and Internet Archive (Wayback) history.

No API keys, no sign-up, nothing stored. MIT licensed.

Repo: https://github.com/yessGlory17/job-verify