### PR TITLE
Add ChronoVerify to Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,7 @@ the number of views or likes.
 ### Image
   
 - [Image verification assisant](https://mever.gr/forensics/) - Imge verification assisant helps you to analyse the varacity of online media
+- [ChronoVerify](https://chronoverify.com/) - Free image capture time and provenance checker: validates C2PA Content Credentials, checks EXIF/XMP consistency, and runs pixel forensics, returning one verdict with a confidence score.
 - [Google Images](https://images.google.com/) - Google image search
 - [Yandex Images](https://yandex.com/images/) - Yandex Image search
 - [Bing Images](https://www.bing.com/images) - Bing Image search


### PR DESCRIPTION
Adds ChronoVerify to the Image section, next to the existing image verification entry.

Link: https://chronoverify.com/

Free image capture time and provenance checker: validates C2PA Content Credentials against the official trust lists, checks EXIF/XMP internal consistency, and runs classical pixel forensics, returning one plain-language verdict with a confidence score. Images are processed in memory and never stored. Provenance validation, not a deepfake detector, and it says so plainly.

Disclosure: I built ChronoVerify (self-promotional submission, stated up front).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
