### PR TITLE
Add DNSai to DOMAIN / IP / DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1574,6 +1574,7 @@ Enter two images and the difference will show up below
 - [CertGrep](https://certgrep.sh/) - SSL/TLS certificate search and monitoring.
 - [TriNetLayer](https://trinetlayer.com/) - Network layer analysis and IP intelligence.
 - [IPLoop](https://iploop.io) - Residential proxy platform (2M+ IPs, 195+ countries). Route OSINT recon through real residential IPs. Python SDK with 66 site presets.
+- [DNSai](https://dnsai.com/dns-tools/) - Free, no-signup DNS/WHOIS lookups, DKIM selector discovery, SPF/DMARC analysis, email header analysis and blacklist checks
 <br>
 
 [⇧ Top](#index)


### PR DESCRIPTION
DNSai adds a few things the existing lookup tools in this section don't cover: DKIM selector discovery (finds a domain's signing keys without knowing selector names), SPF analysis with the 10-DNS-lookup limit check, plain-English interpretation of results aimed at non-experts, and a free API plus MCP server so the same checks run inside AI assistants. All basic lookups are free with no signup or ads.

Disclosure: I'm the founder of DNSai. Happy to adjust wording or placement, and no hard feelings if it's not a fit for the list.
