### PR TITLE
Add IntelCue Subdomain Finder to Recon section

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Tools for Image/Audio/Video/Doc reconnaissance
 - [Raccoon](https://github.com/evyatarmeged/Raccoon) - High performance offensive security tool for reconnaissance and vulnerability scanning.
 - [ivre](https://github.com/ivre/ivre) - Network recon framework to build alternatives to Shodan/ZoomEye/Censys.
 - [Findomain](https://github.com/Findomain/Findomain) - Fast domain recognition tool with screenshotting, port scan, and subdomain monitoring.
+- [IntelCue Subdomain Finder](https://www.intelcue.ai/tools/subdomain-finder) - Free subdomain finder powered by Certificate Transparency logs, no signup required.
 <br>
 
 [⇧ Top](#index)


### PR DESCRIPTION
Adds IntelCue Subdomain Finder (https://www.intelcue.ai/tools/subdomain-finder) to the Recon section, after Findomain.

**Disclosure:** I'm affiliated with IntelCue. This is a free, no-signup subdomain finder built on Certificate Transparency logs — no account or API key required, fitting alongside Amass/Subfinder/Findomain already listed here.

Ran `npm install && npm run link-check` per CONTRIBUTING.md — the new link passes (✓); the 370 pre-existing dead links reported are unrelated to this change.