### PR TITLE
Add Jura Trace to AI Detection & Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ In addition search for Wifi networks and look for planes, vessels, trains and ci
 - [Anything](https://anything.com) -  just describe what you want, and anything builds it. Everything you need built in.
 
 ### AI Detection & Verification
+- [Jura Trace](https://juralabs.org/) - Open-source (AGPL), local-first desktop app for image authenticity verification: C2PA provenance signing, EXIF forensics, and a trained AI/deepfake image classifier, all on-device with no upload.
 - [r/RealOrAI](https://www.reddit.com/r/RealOrAI/) - Reddit community for detecting AI-generated content.
 - [VerifiedHer](https://verifiedher.com/) - Registry answering "is she real?" for online creators — sourced verdicts (real / AI persona / unverified), verified account lists, and impersonation warnings for 400+ documented creators.
 


### PR DESCRIPTION
Adds one tool to the **AI Detection & Verification** section under `## AI`.

**Jura Trace** — open-source (AGPL-3.0-or-later), local-first desktop app for image authenticity verification. Runs C2PA provenance signing/verification, EXIF/metadata forensics, and a trained AI-generated-image/deepfake classifier entirely on-device, no upload to any server. Built by Jura Labs, a UK Community Interest Company.

- Verified the link resolves (200).
- Placed alphabetically ahead of the existing `r/RealOrAI` entry.
- Kept to a single section/single line per the contributing guide's note against duplicate/spammy entries, even though the tool would also fit under Video OSINT & Verification or Metadata & File Analysis — this section is the closest match to what it actually does.

Disclosure: I'm affiliated with Jura Labs (the project's publisher), submitting per the contributing guide's process for adding new tools.