### PR TITLE
Add LinksGone to PRIVACY / SECURITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Cut down on data collection and protect your sensitive personal information, hea
 - [Speech Jammer](https://mynoise.net/NoiseMachines/audioJammerNoiseGenerator.php) - Audio jammers are popular tools used during confidential meetings. They produce a unique sound for masking and protecting conversations from external listening devices, such as a smartphone running an audio recording app, hidden in one of your guests' pocket
 - [Stutterbox](https://www.stutterbox.co.uk/) - A speech jammer is a device that inhibits a user from speaking in coherent sentences due to the user hearing their own voice played back to them with a slight delay.
 - [StegOnline](https://stegonline.georgeom.net/upload) - A web-based, enhanced and open-source port of StegSolve. Upload any image file, and the relevant options will be displayed.
+- [LinksGone](https://www.linksgone.com/) - Free tool that prepares the correct platform-specific removal notice for deepfakes, non-consensual intimate images, and online impersonation; the victim files it in their own name and shares links only, never images.
 <br>
 
 [⇧ Top](#index)


### PR DESCRIPTION
## What

Adds one entry to the PRIVACY / SECURITY section:

`- [LinksGone](https://www.linksgone.com/) - Free tool that prepares the correct platform-specific removal notice for deepfakes, non-consensual intimate images, and online impersonation; the victim files it in their own name and shares links only, never images.`

## Why it fits

The PRIVACY / SECURITY section covers the defensive side: guides and tools people use to protect themselves. When someone finds impersonation accounts, deepfakes of themselves, or leaked intimate images, the next step is getting them taken down. LinksGone works out which platform form or contact applies and prepares the notice; the person files it themselves. The takedown flow is free (optional paid extras exist: done-for-you filing and monitoring). It never handles the abusive content itself - users share links, never images - and intimate-image cases are pointed to StopNCII (adults) or NCMEC Take It Down (minors) first.

Disclosure: I build LinksGone.

Link verified working (HTTP 200). Formatting follows the existing entry style of the section.