### PR TITLE
Add MyIPScan to DOMAIN / IP / DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1581,6 +1581,7 @@ Enter two images and the difference will show up below
 - [CertGrep](https://certgrep.sh/) - SSL/TLS certificate search and monitoring.
 - [TriNetLayer](https://trinetlayer.com/) - Network layer analysis and IP intelligence.
 - [IPLoop](https://iploop.io) - Residential proxy platform (2M+ IPs, 195+ countries). Route OSINT recon through real residential IPs. Python SDK with 66 site presets.
+- [MyIPScan](https://myipscan.net/tools/) - Browser-based lookups for IP, ASN, WHOIS/RDAP, reverse DNS, DNS records and provider IP ranges, plus DNS, WebRTC and IPv6 leak tests. Free, no account, nothing to install.
 <br>
 
 [⇧ Top](#index)


### PR DESCRIPTION
Adding MyIPScan to the DOMAIN / IP / DNS section, next to the other browser-based lookup services (dnslytics, ViewDNS.info, IPLeak, IPinfo). Free and browser-based, no account or install: IP and ASN lookup, WHOIS/RDAP, reverse DNS, DNS records, provider IP ranges, plus DNS/WebRTC/IPv6 leak tests.

Disclosure: I maintain this site. Happy for you to close this if it does not fit.