### PR TITLE
Add StackScan to DOMAIN / IP / DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1534,6 +1534,7 @@ Enter two images and the difference will show up below
 - [photon](https://pypi.org/project/photon/) - Incredibly fast crawler designed for OSINT.
 - [Technology Lookup](https://osint.sh/stack/) - Technology stack checker tool. Check out the technologies used on any website.
 - [BuiltWith Technology Lookup](https://builtwith.com/) - Find out what websites are Built With
+- [StackScan](https://www.stackscan.com/) - Look up a site's technology stack, or start from a technology to get the sites using it, broken down by country and industry. Free tier on signup.
 - [OSINT.SH](https://osint.sh/) - All in one Information Gathering Tools
 - [Nmap Checker Tool](https://shadowcrypt.net/tools/nmap) - Online Free Hacking Tools - ShadowCrypt
 - [Free online network tools](https://centralops.net/co/) - Free online network tools - traceroute, nslookup, dig, whois lookup, ping - IPv6


### PR DESCRIPTION
Adds StackScan to the URL's subsection under DOMAIN / IP / DNS, next to the other technology lookup tools.

**Disclosure: I work for StackScan.**

It does the same domain to stack lookup as the entries around it, and adds two reverse directions:

- **Technology to sites.** Pick a technology and get the sites and companies running it, with country and industry breakdowns.
- **Asset to sites.** Give it a file name, an asset path, or the host an asset loads from, and get every site carrying that footprint.

The asset search is the reason I think it sits well alongside Wappalyzer and BuiltWith rather than duplicating them. A catalogue only contains what someone wrote a detector for, so a self-hosted bundle, one build of a theme, or an internal SDK has no entry. Searching the asset index finds those anyway, which makes it a pivot: take a script path from one site and get every other site serving it.

Free tier on email verification: 100 lifetime API credits, one list, and custom footprint scans. Technology statistics pages can be browsed without an account.